### PR TITLE
Revert "Fix Template Error with Empty Hash"

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "daniel.j.jimenez@gmail.com"
 license          "Apache License, Version 2.0"
 description      "Provides integration with teamcity for getting bits from teamcity or setup build agents"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.2.8"
+version          "0.2.7"
 
 recommends "java"
 

--- a/templates/default/buildAgent.properties.erb
+++ b/templates/default/buildAgent.properties.erb
@@ -59,7 +59,7 @@ system.<%= key %>=<%= value %>
 <%- end %>
 
 # Environment Variables
-<%- unless @env_properties.empty? or @env_properties.nil? %>
+<%- unless @env_properties.nil? %>
 <%- @env_properties.to_hash.sort.each do |key,value| %>
 env.<%= key %>=<%= value %>
 <%- end %>


### PR DESCRIPTION
Reverts foreflight/chef-teamcity#1

This was actually incorrect.  Reasoning was sound, but was not the initial issue.  It should remain `.nil?` only, or `.nil?` first.